### PR TITLE
Set `MALLOC_ARENA_MAX` to avoid excessive memory usage by preallocated arenas

### DIFF
--- a/tool_run_scripts/anvill.py
+++ b/tool_run_scripts/anvill.py
@@ -66,6 +66,16 @@ class AnvillGhidraCmd(ToolCmd):
         ])
         return args
 
+    def make_env(self) -> dict[str, str]:
+        # glibc preallocates arenas per thread to improve allocation performance. For machines with
+        # a high core count, this can dwarf the amount of memory used by the JVM's heap or
+        # internals. This is a problem when running on environments like GHA with a hard memory
+        # constraint as jobs will be repeatedly killed. We should set `MALLOC_ARENA_MAX` to limit
+        # the number of arenas that glibc is allowed to allocate.
+        #
+        #   https://thehftguy.com/2020/05/21/major-bug-in-glibc-is-killing-applications-with-a-memory-limit/
+        return {"MALLOC_ARENA_MAX": "4"}
+
     def save(self):
         if self.rc is None:
             raise RuntimeError("Return code never set")


### PR DESCRIPTION
Did a bit of digging and figured out what was going on with the GHA OOMs I was seeing after moving the challenge testing to the Irene3 repo.

I couldn't exactly replicate the **extreme** memory usage on my machine or in DO but I did notice that memory usage was significantly higher than the configured heap size (and high usage wasn't shown in a heap dump). That's somewhat expected since the JVM's internals have overhead but it seemed a bit more than normal based on what I was reading. When running with `-XX:NativeMemoryTracking=summary` and querying native memory usage, I didn't see anything in the GB territory.

Eventually I stumbled upon [this article](https://thehftguy.com/2020/05/21/major-bug-in-glibc-is-killing-applications-with-a-memory-limit/), which explains that arenas are allocated for each thread and that, on machines with a high core count, this overhead can be high. This would explain why none of the introspection tools I used could spot this memory usage. Once I ran with this environment variable set, the memory usage was lower when testing locally and the GHA jobs were able to complete without being killed.