### PR TITLE
AnghaBench fixes for Angha50

### DIFF
--- a/datasets/architectures.txt
+++ b/datasets/architectures.txt
@@ -2,3 +2,5 @@ amd64
 armv7
 arm64
 x86
+thumb
+powerpc

--- a/datasets/fetch_anghabench.sh
+++ b/datasets/fetch_anghabench.sh
@@ -16,7 +16,7 @@ function Help
   echo ""
   echo "Options:"
   echo "  --clang           Which version of clang built the dataset [${CLANG}]"
-  echo "  --run-size        How many binaries (choices: 1k, 1m)"
+  echo "  --run-size        How many binaries (choices: 50, 1k, 1m)"
   echo "  --bitcode         Fetch bitcode"
   echo "  --binaries        Fetch binaries (ELF .o)"
   echo "  -h --help         Print help."

--- a/tool_run_scripts/anvill.py
+++ b/tool_run_scripts/anvill.py
@@ -307,6 +307,9 @@ def anvill_python_main(args, source_path, dest_path):
     # Filter for files that are executable
     sources = [source for source in source_path.rglob("*") if source.is_file() and os.access(source, os.X_OK) and not source.name.startswith(".")]
 
+    # Add objects to source list. This is required for AnghaBench.
+    sources.extend(list(source_path.rglob("*.o")))
+
     log.info(f"Found {len(sources)} Executable files")
 
     # load test to ignore


### PR DESCRIPTION
The Angha test programs aren't executables, they're usually just a single function that is built into an object. We need this to re-introduce AnghaBench testing back into Anvill CI.

Also a few changes to add the new architectures we're supporting in AnghaBench + the new Angha50 variant.